### PR TITLE
Update Memory.java

### DIFF
--- a/src/main/java/org/androidsoft/games/memory/tux/Memory.java
+++ b/src/main/java/org/androidsoft/games/memory/tux/Memory.java
@@ -157,7 +157,6 @@ public class Memory
         }
         mLastPosition = position;
         Tile tile = mList.get(position);
-        tile.select();
         int sound = tile.mResId % mSounds.length;
         SoundManager.instance().playSound( sound );
 
@@ -192,6 +191,7 @@ public class Memory
                 mT1 = tile;
                 break;
         }
+        tile.select();
         mSelectedCount++;
         mMoveCount++;
         updateView();


### PR DESCRIPTION
Moving the "tile.select()" to below the switch case block to fix the viewing issue when re-selecting the first of the two previously selected tiles.
